### PR TITLE
Fix dependencies

### DIFF
--- a/scope_cache_key.gemspec
+++ b/scope_cache_key.gemspec
@@ -16,10 +16,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency('activerecord', '>= 3.2.9')
+  gem.add_runtime_dependency('activerecord', '~> 3.2.12', '>= 3.2.9')
 
   gem.add_development_dependency('rspec', '~> 2.13.0')
-  gem.add_development_dependency('activerecord', '~> 3.2.12')
   gem.add_development_dependency('actionpack', '~> 3.2.12')
   gem.add_development_dependency('faker', '~> 1.1.2')
   gem.add_development_dependency('pry')


### PR DESCRIPTION
scope_cache_key at ../bundler/gems/scope_cache_key-04b35b42dd53 did not have a valid gemspec.
       This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
       The validation message from Rubygems was:
       duplicate dependency on activerecord (~> 3.2.12, development), (>= 3.2.9) use:
       add_runtime_dependency 'activerecord', '~> 3.2.12', '>= 3.2.9'
